### PR TITLE
Handle bad HTTP response

### DIFF
--- a/lib/output/http.ex
+++ b/lib/output/http.ex
@@ -8,7 +8,7 @@ defmodule Logger.Backend.Splunk.Output.Http do
     opts = [hackney: [pool: :logger_splunk_backend]]
     case HTTPoison.post(host, msg, headers, opts) do
       {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.warn("HTTP POST request failed: #{inspect reason}")
+        Logger.warn("Splunk Logger HTTP POST request failed: #{inspect reason}")
       {:ok, _response} ->
         nil
     end

--- a/lib/output/http.ex
+++ b/lib/output/http.ex
@@ -1,10 +1,16 @@
 defmodule Logger.Backend.Splunk.Output.Http do
+  require Logger
+
   def transmit(entry, host, token) do
     msg = Poison.encode!(%{sourcetype: "httpevent", event: entry})
 
-    {:ok, _response} = HTTPoison.post(host, msg,
-      [{"Authorization", "Splunk #{token}"},
-       {"Content-Type", "application/json"}],
-      [hackney: [pool: :logger_splunk_backend]])
+    headers = [{"Authorization", "Splunk #{token}"}, {"Content-Type", "application/json"}]
+    opts = [hackney: [pool: :logger_splunk_backend]]
+    case HTTPoison.post(host, msg, headers, opts) do
+      {:error, %HTTPoison.Error{reason: reason}} ->
+        Logger.warn("HTTP POST request failed: #{inspect reason}")
+      {:ok, _response} ->
+        nil
+    end
   end
 end


### PR DESCRIPTION
Logs a warning when HTTP POST to splunk is not successful instead of crashing.