### PR TITLE
Don't log a warning when you can't log a warning

### DIFF
--- a/lib/output/http.ex
+++ b/lib/output/http.ex
@@ -6,11 +6,6 @@ defmodule Logger.Backend.Splunk.Output.Http do
 
     headers = [{"Authorization", "Splunk #{token}"}, {"Content-Type", "application/json"}]
     opts = [hackney: [pool: :logger_splunk_backend]]
-    case HTTPoison.post(host, msg, headers, opts) do
-      {:error, %HTTPoison.Error{reason: reason}} ->
-        Logger.warn("Splunk Logger HTTP POST request failed: #{inspect reason}")
-      {:ok, _response} ->
-        nil
-    end
+    HTTPoison.post(host, msg, headers, opts)
   end
 end


### PR DESCRIPTION
We can't log a warning when splunk can't send a warning. It will try to send that warning.