### PR TITLE
send logs to Splunk in batches

### DIFF
--- a/lib/logger_splunk_backend.ex
+++ b/lib/logger_splunk_backend.ex
@@ -74,10 +74,10 @@ defmodule Logger.Backend.Splunk do
   end
 
   @unix_epoch :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
-  def ts_to_unix({date, {h, m, s, _}}) do
+  def ts_to_unix({date, {h, m, s, ms}}) do
     # drop the sub-second value
     gregorian_seconds = :calendar.datetime_to_gregorian_seconds({date, {h, m, s}})
-    gregorian_seconds - @unix_epoch
+    (gregorian_seconds - @unix_epoch) + (ms / 1000)
   end
 
   defp format_event(level, msg, ts, md, %{compiled_format: format, metadata: keys}) do

--- a/lib/logger_splunk_backend.ex
+++ b/lib/logger_splunk_backend.ex
@@ -86,7 +86,7 @@ defmodule Logger.Backend.Splunk do
   end
 
   def maybe_send(%{buffer_size: bs, max_buffer: mb} = state) when bs >= mb do
-    state.connector.transmit(Enum.reverse(state.buffer), state.host, state.token)
+    state.connector.transmit(state.buffer, state.host, state.token)
     %{state |
       buffer: [],
       buffer_size: 0

--- a/lib/output/http.ex
+++ b/lib/output/http.ex
@@ -2,10 +2,8 @@ defmodule Logger.Backend.Splunk.Output.Http do
   require Logger
 
   def transmit(entry, host, token) do
-    msg = Poison.encode!(%{sourcetype: "httpevent", event: entry})
-
     headers = [{"Authorization", "Splunk #{token}"}, {"Content-Type", "application/json"}]
     opts = [hackney: [pool: :logger_splunk_backend]]
-    HTTPoison.post(host, msg, headers, opts)
+    HTTPoison.post(host, IO.iodata_to_binary(entry), headers, opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -23,7 +23,7 @@ defmodule LoggerSplunkBackend.Mixfile do
   defp deps do
     [
       {:httpoison, "~> 1.0"},
-      {:poison, "~> 3.1"}
+      {:jason, "~> 1.0"}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,9 +1,12 @@
-%{"certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
+%{
+  "certifi": {:hex, :certifi, "2.0.0", "a0c0e475107135f76b8c1d5bc7efb33cd3815cb3cf3dea7aefdd174dabead064", [:rebar3], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.10.1", "c38d0ca52ea80254936a32c45bb7eb414e7a96a521b4ce76d00a69753b157f21", [:rebar3], [{:certifi, "2.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "5.1.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},
   "httpoison": {:hex, :httpoison, "1.0.0", "1f02f827148d945d40b24f0b0a89afe40bfe037171a6cf70f2486976d86921cd", [:mix], [{:hackney, "~> 1.8", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
+  "jason": {:hex, :jason, "1.1.1", "d3ccb840dfb06f2f90a6d335b536dd074db748b3e7f5b11ab61d239506585eb2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},
   "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [], [], "hexpm"},
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.1", "28a4d65b7f59893bc2c7de786dec1e1555bd742d336043fe644ae956c3497fbe", [:make, :rebar], [], "hexpm"},
-  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"}}
+  "unicode_util_compat": {:hex, :unicode_util_compat, "0.3.1", "a1f612a7b512638634a603c8f401892afbf99b8ce93a45041f8aaca99cadb85e", [:rebar3], [], "hexpm"},
+}

--- a/test/logger_splunk_backend_test.exs
+++ b/test/logger_splunk_backend_test.exs
@@ -34,7 +34,8 @@ defmodule Logger.Backend.Splunk.Test do
       connector: Output.Test,
       host: 'splunk.url',
       format: "[$level] $message",
-      token: "<<splunk-token>>"
+      token: "<<splunk-token>>",
+      max_buffer: 0
     ])
     on_exit fn ->
       connector().destroy()
@@ -96,6 +97,21 @@ defmodule Logger.Backend.Splunk.Test do
     assert read_log() =~ "[info] hello"
     Logger.info("hello\n")
     assert read_log() =~ "[info] hello\\n"
+  end
+
+  test "buffers messages" do
+    config(max_buffer: 2)
+    Logger.info("hello")
+    refute read_log()
+    Logger.info("again")
+    assert read_log() =~ "hello"
+    assert read_log() =~ "again"
+    connector().destroy()
+    Logger.info("1")
+    refute read_log()
+    Logger.info("2")
+    assert read_log() =~ "1"
+    assert read_log() =~ "2"
   end
 
   defp config(opts) do

--- a/test/logger_splunk_backend_test.exs
+++ b/test/logger_splunk_backend_test.exs
@@ -60,7 +60,7 @@ defmodule Logger.Backend.Splunk.Test do
     assert connector().exists()
     data = Jason.decode!(read_log())
     assert data["event"] == "[warn] you will log me"
-    assert is_integer(data["time"])
+    assert is_float(data["time"])
     assert data["sourcetype"] == "httpevent"
   end
 


### PR DESCRIPTION
In Busloc (where we're logging a lot of stuff), each line to Splunk individually was taking a bunch of time. This PR refactors the sending so that we buffer the lines and then send them periodically.

This can result in some delay of messages, but since we include the timestamp it's not a big deal.