### PR TITLE
feat: include the host when logging

### DIFF
--- a/lib/logger_splunk_backend.ex
+++ b/lib/logger_splunk_backend.ex
@@ -74,6 +74,7 @@ defmodule Logger.Backend.Splunk do
     map = %{
       event: IO.iodata_to_binary(event),
       sourcetype: "httpevent",
+      host: Atom.to_string(node()),
       time: ts_to_unix(ts)
     }
     Jason.encode_to_iodata!(map)

--- a/test/logger_splunk_backend_test.exs
+++ b/test/logger_splunk_backend_test.exs
@@ -62,6 +62,7 @@ defmodule Logger.Backend.Splunk.Test do
     assert data["event"] == "[warn] you will log me"
     assert is_float(data["time"])
     assert data["sourcetype"] == "httpevent"
+    assert is_binary(data["host"])
   end
 
   test "can configure format" do


### PR DESCRIPTION
I was using this to debug where some mystery log entries were coming from, but it could be useful for other systems as well.