### PR TITLE
fix: don't log unknown messages

### DIFF
--- a/lib/logger_splunk_backend.ex
+++ b/lib/logger_splunk_backend.ex
@@ -87,14 +87,7 @@ defmodule Logger.Backend.Splunk do
     {:ok, state}
   end
 
-  def handle_info(message, state) do
-    IO.puts(state.error_device, [
-      "ERROR ",
-      inspect(__MODULE__),
-      " unhandled message: ",
-      inspect(message)
-    ])
-
+  def handle_info(_message, state) do
     {:ok, state}
   end
 


### PR DESCRIPTION
This updates the behavior to match `Logger.Console` which also silently ignores unknown messages:
https://github.com/elixir-lang/elixir/blob/v1.12.3/lib/logger/lib/logger/backends/console.ex#L174-L176